### PR TITLE
fix(audit): A1 — escape HTML in JSON-LD (stored XSS)

### DIFF
--- a/src/components/seo/Seo.tsx
+++ b/src/components/seo/Seo.tsx
@@ -10,6 +10,32 @@ import {
 
 type JsonLd = Record<string, unknown>;
 
+/**
+ * Serialize a JSON-LD object for safe embedding inside a
+ * <script type="application/ld+json"> element.
+ *
+ * JSON.stringify does NOT escape `<`, `>` or `&`, so owner/guest-controlled
+ * content (property name/description, review comments) could otherwise break
+ * out of the script with a literal `</script>` sequence and inject markup
+ * (stored XSS). Escaping these characters — plus the U+2028/U+2029 line
+ * separators that are invalid in JS string literals — neutralises any
+ * breakout regardless of upstream content.
+ *
+ * The line/paragraph separators are matched via fromCharCode-built RegExp
+ * objects so this source file stays ASCII — embedding those code points
+ * literally inside a /regex/ breaks the parser (they are line terminators).
+ */
+const LINE_SEPARATOR = new RegExp(String.fromCharCode(0x2028), 'g');
+const PARAGRAPH_SEPARATOR = new RegExp(String.fromCharCode(0x2029), 'g');
+
+const toJsonLd = (obj: JsonLd): string =>
+  JSON.stringify(obj)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(LINE_SEPARATOR, '\\u2028')
+    .replace(PARAGRAPH_SEPARATOR, '\\u2029');
+
 export interface SeoProps {
   /** Page title. The "| Aparte" brand suffix is appended unless brandSuffix=false. */
   title?: string;
@@ -80,7 +106,7 @@ const Seo = ({
 
       {blocks.map((block, i) => (
         <script key={i} type="application/ld+json">
-          {JSON.stringify(block)}
+          {toJsonLd(block)}
         </script>
       ))}
     </Helmet>


### PR DESCRIPTION
## Finding A1 (HIGH) — Stored XSS via unescaped JSON-LD

**Finding ID:** A1 &nbsp;|&nbsp; **Severity:** HIGH

### What was wrong
`src/components/seo/Seo.tsx` emitted JSON-LD blocks as `{JSON.stringify(block)}` inside a `<script type="application/ld+json">` element. `JSON.stringify` does **not** escape `<`, `>` or `&`, so owner/guest-controlled content — property name/description and review comments, sourced from `src/lib/seo/schema.ts` (`node.name`, `node.description`, `review.reviewBody`, author names) — could break out of the script element with a literal `</script>...` sequence and inject arbitrary markup. This is a stored XSS sink.

### What changed
Scope: **only `src/components/seo/Seo.tsx`** (1 file, +27 / -1).

- Added a `toJsonLd()` serializer that escapes `<` → `<`, `>` → `>`, `&` → `&`, plus the U+2028/U+2029 line separators, before the string enters the script element.
- Replaced the single `{JSON.stringify(block)}` render with `{toJsonLd(block)}`.

This neutralizes any `</script>` breakout regardless of upstream content. The escaped output is still valid JSON and round-trips losslessly (consumers/crawlers parse identical data). The line/paragraph separators are matched via `String.fromCharCode`-built `RegExp` objects so the source file stays ASCII (embedding those code points literally inside a `/regex/` breaks the TS/JS parser — they are line terminators).

`src/lib/seo/schema.ts` was read for context only and intentionally left unchanged — escaping at the sink fixes every JSON-LD path at once.

### How it was validated
- **Production build:** `npm install` then `npm run build` (`generate-sitemap` + `tsc -b` + `vite build`) — **PASS** (exit 0). `tsc -b` compiles with no errors; bundle builds. (The build's `generate-sitemap` prestep rewrote `public/sitemap.xml`; that artifact was reverted so the PR contains only the `Seo.tsx` change.)
- **Standalone fail-before / pass-after assertion** (Node, against the escaping logic — landing-page has no unit-test framework):
  - Payload: `</script><img src=x onerror=alert(1)>` as a property name.
  - Fail-before: raw `JSON.stringify` output contains literal `</script>` and `<img` (breakout possible).
  - Pass-after: `toJsonLd` output is `</script><img src=x onerror=alert(1)>` — **no** raw `<`/`>`, no literal `</script>`.
  - Round-trip: `JSON.parse(toJsonLd(block)).name` equals the exact original payload (no data loss).
  - U+2028/U+2029 separators escaped and round-trip verified.
  - Result: **ALL ASSERTIONS PASSED** (exit 0).

### Residual risk
- **No unit-test infrastructure in repo** — landing-page has no test framework; per the remediation envelope none was added. Correctness was proven via the build plus the standalone Node assertion described above. Consider adding a Vitest case for `toJsonLd` in a future, separately-scoped change.
- Fix is defense-at-the-sink; it does not alter `schema.ts` input handling (not required — escaping covers all current and future JSON-LD producers feeding `<Seo jsonLd>`).

---

Authored by remediation agent — requires human review. Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
