### PR TITLE
fix(audit): A5 — remove debug console.log from production paths

### DIFF
--- a/src/api/bookingsApi.ts
+++ b/src/api/bookingsApi.ts
@@ -186,11 +186,9 @@ export const bookingsApi = createApi({
     getBookingExtensions: builder.query<ExtensionsResponse, string>({
       query: (bookingId) => `bookings/${bookingId}/extensions`,
       providesTags: (_result, _error, bookingId) => [{ type: 'Bookings' as const, id: 'EXT' + bookingId }],
-      async onQueryStarted(bookingId, { queryFulfilled }) {
-        console.log('Fetching extensions for booking:', bookingId);
+      async onQueryStarted(_bookingId, { queryFulfilled }) {
         try {
-          const { data } = await queryFulfilled;
-          console.log('Extensions fetched successfully:', data);
+          await queryFulfilled;
         } catch (err) {
           console.error('Error fetching extensions:', err);
         }
@@ -210,11 +208,9 @@ export const bookingsApi = createApi({
         { type: 'Bookings' as const, id: 'EXT' + bookingId },
         { type: 'Bookings' as const },
       ],
-      async onQueryStarted({ bookingId }, { queryFulfilled }) {
-        console.log('Requesting stay extension for booking:', bookingId);
+      async onQueryStarted(_arg, { queryFulfilled }) {
         try {
-          const { data } = await queryFulfilled;
-          console.log('Stay extension requested successfully:', data);
+          await queryFulfilled;
         } catch (err) {
           console.error('Error requesting stay extension:', err);
         }

--- a/src/components/Idletimeout/idletimeout.tsx
+++ b/src/components/Idletimeout/idletimeout.tsx
@@ -92,11 +92,8 @@ const IdleTimeoutWithWarning: React.FC<IdleTimeoutWithWarningProps> = ({
   useEffect(() => {
     // Don't start timer if not authenticated
     if (!isAuthenticated) {
-      console.log('User not authenticated, idle timer disabled');
       return;
     }
-
-    console.log('User authenticated, starting idle timer');
 
     // Track user activity
     const events = [

--- a/src/components/booking/PaymentMethodSelection.tsx
+++ b/src/components/booking/PaymentMethodSelection.tsx
@@ -27,7 +27,6 @@ const PaymentMethodSelection: React.FC<PaymentMethodSelectionProps> = ({
   wallet,
   formatPrice,
 }) => {
-  console.log('paymentGateway', paymentGateway);
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
       <h2 className="text-xl font-medium mb-4">Payment Method</h2>

--- a/src/components/forms/FormContainer.tsx
+++ b/src/components/forms/FormContainer.tsx
@@ -51,7 +51,6 @@ const FormContainer: React.FC<FormContainerProps> = ({
             disabled={loading}
             {...submitButtonProps}
             onClick={(e) => {
-              console.log('FormContainer button clicked');
               submitButtonProps?.onClick?.(e);
             }}
             className={`w-[95%] bg-[#028090] text-white rounded-lg py-3 ml-3 transition-colors ${loading ? 'opacity-70 cursor-not-allowed' : 'hover:bg-[#026d7a] cursor-pointer active:bg-[#025e6b]'

--- a/src/components/search/ResultsGrid.tsx
+++ b/src/components/search/ResultsGrid.tsx
@@ -19,8 +19,6 @@ interface ResultsGridProps {
 }
 
 export const ResultsGrid: React.FC<ResultsGridProps> = ({ isFetching, apartments }) => {
-  console.log('ResultsGrid apartments:', apartments);
-
   if (isFetching) {
     return <PropertyCardSkeleton count={6} columns={{ xs: 12, sm: 6, md: 4 }} />;
   }

--- a/src/context/UserBooking.tsx
+++ b/src/context/UserBooking.tsx
@@ -31,8 +31,6 @@ export const BookingProvider = ({ children, onError }: BookingProviderProps) => 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  console.log('BookingProvider rendered with booking:', booking, 'isLoading:', isLoading, 'error:', error);
-
   // Load booking from storage on mount
   useEffect(() => {
     const loadBooking = async () => {

--- a/src/pages/ConfirmBooking.tsx
+++ b/src/pages/ConfirmBooking.tsx
@@ -278,7 +278,6 @@ const ConfirmBooking = () => {
         setCreatedBookingId(bookingId);
 
         if (bookingId && readShouldShowPayoutNudgeFromCreateBooking(bookingResponse)) {
-          console.log('bookingId', bookingId);
           setPayoutNudgePendingForBooking(bookingId);
         }
 

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -102,7 +102,6 @@ export default function PaymentSuccess() {
   useEffect(() => {
     if (bookinginfo?.status === 'PENDING') {
       const retryInterval = setInterval(() => {
-        console.log(`Auto-retrying... (attempt ${retryCount + 1})`);
         setRetryCount((prev) => prev + 1);
 
         patchBookingStatus({

--- a/src/pages/PropertyDetails.tsx
+++ b/src/pages/PropertyDetails.tsx
@@ -239,12 +239,6 @@ const PropertyDetails: React.FC = () => {
   useEffect(() => {
     if (!isLoading && data) {
       setPropertyDetail(data?.data);
-      console.log('API Response:', data);
-      console.log('Property coordinates:', {
-        lat: data?.data?.latitude,
-        lng: data?.data?.longitude,
-        rawData: data?.data,
-      });
       if (data?.data?.units && data?.data?.units?.length > 0) {
         setValue(data?.data?.units[0]?.id);
       }

--- a/src/pages/auth/EmailInput.tsx
+++ b/src/pages/auth/EmailInput.tsx
@@ -37,8 +37,6 @@ const EmailInput: React.FC<EmailInputProps> = ({ mode, role, onComplete }) => {
   const handleEmailSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    console.log(email);
-
     setError('');
     setSuccess('');
 
@@ -101,7 +99,6 @@ const EmailInput: React.FC<EmailInputProps> = ({ mode, role, onComplete }) => {
         }
         navigate('/'); // Redirect to the landing page
       } catch (err: any) {
-        console.log('Error: ', err);
         setLoading(false);
         if (err.data && err.data.errors && err.data.errors.length > 0) {
           setError(err.data.errors[0].message);
@@ -115,8 +112,7 @@ const EmailInput: React.FC<EmailInputProps> = ({ mode, role, onComplete }) => {
   };
 
   // Handle OTP completion
-  const handleOtpComplete = (otp: string) => {
-    console.log('OTP entered:', otp);
+  const handleOtpComplete = (_otp: string) => {
     setSuccess('OTP verified successfully!');
   };
 

--- a/src/pages/auth/RequestPasswordReset.tsx
+++ b/src/pages/auth/RequestPasswordReset.tsx
@@ -63,7 +63,6 @@ const RequestPasswordReset = () => {
       toast.success(response.message || 'Reset instructions sent');
       navigate(`/auth/reset-password?${inputMode}=${encodeURIComponent(inputMode === 'email' ? email : phoneWithCode || '')}`);
     } catch (err) {
-      console.log('Password reset error:', err);
       const errorMessage = extractErrorMessage(err, 'Failed to send reset instructions');
       toast.error(errorMessage);
     } finally {

--- a/src/pages/auth/ResetPassword.tsx
+++ b/src/pages/auth/ResetPassword.tsx
@@ -18,8 +18,6 @@ interface ApiError {
 }
 
 const ResetPassword = () => {
-  console.log('API Base URL:', import.meta.env.VITE_API_BASE_URL);
-
   const navigate = useNavigate();
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
@@ -28,8 +26,7 @@ const ResetPassword = () => {
   const phone = queryParams.get('phone');
   const country = "Nigeria (+234)"; // Default country code
 
-  const [resetPassword, { isLoading: mutationLoading, error: mutationError }] = useResetPasswordMutation();
-  console.log('Reset password mutation:', { resetPassword, mutationLoading, mutationError });
+  const [resetPassword] = useResetPasswordMutation();
 
   const [otp, setOtp] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -40,75 +37,50 @@ const ResetPassword = () => {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log('Form submission started');
-    console.log('Current form state:', {
-      otp,
-      newPassword: newPassword ? '[PRESENT]' : '[EMPTY]',
-      confirmPassword: confirmPassword ? '[PRESENT]' : '[EMPTY]',
-      inputMode,
-      email,
-      phone
-    });
 
     // Validate inputs
     if (!otp.trim()) {
-      console.log('Validation failed: OTP empty');
       toast.error('Please enter the OTP');
       return;
     }
-    console.log('OTP validation passed');
 
     if (otp.length !== 6) {
-      console.log('Validation failed: OTP length invalid');
       toast.error('Please enter a valid 6-digit OTP');
       return;
     }
-    console.log('OTP length validation passed');
 
     if (!newPassword.trim()) {
-      console.log('Validation failed: Password empty');
       toast.error('Please enter a new password');
       return;
     }
-    console.log('Password presence validation passed');
 
     if (newPassword.length < 8) {
-      console.log('Validation failed: Password too short');
       toast.error('Password must be at least 8 characters long');
       return;
     }
-    console.log('Password length validation passed');
 
     if (!confirmPassword.trim()) {
-      console.log('Validation failed: Confirm password empty');
       toast.error('Please confirm your password');
       return;
     }
-    console.log('Confirm password presence validation passed');
 
     if (newPassword !== confirmPassword) {
-      console.log('Validation failed: Passwords do not match');
       toast.error('Passwords do not match');
       return;
     }
-    console.log('Password match validation passed');
 
     // Validate that we have either email or phone
     if (inputMode === 'email' && !email) {
-      console.log('Validation failed: Email required but missing');
       toast.error('Email is required');
       return;
     }
     if (inputMode === 'phone' && !phone) {
-      console.log('Validation failed: Phone required but missing');
       toast.error('Phone number is required');
       return;
     }
-    console.log('Contact method validation passed');
 
     try {
       setLoading(true);
-      console.log('All validations passed, preparing request data...');
       const countryCode = country.match(/\(([^)]+)\)/)?.[1] || '';
       // Format phone number: remove any non-digit characters and ensure it starts with the country code
       const formattedPhone = phone ? phone.replace(/\D/g, '') : '';
@@ -123,27 +95,13 @@ const ResetPassword = () => {
         password: newPassword,
         password_confirmation: confirmPassword,
       };
-      console.log('Sending request with data:', {
-        ...requestData,
-        password: '[REDACTED]',
-        inputMode,
-        email: email || undefined,
-        phone: phoneWithCode || undefined
-      });
 
       try {
-        console.log('Calling resetPassword mutation...');
-        console.log('resetPassword function type:', typeof resetPassword);
-        console.log('resetPassword function:', resetPassword);
-
         // Try direct mutation call
         const result = resetPassword(requestData);
-        console.log('Immediate mutation result:', result);
 
         if (typeof result === 'object' && 'unwrap' in result) {
-          console.log('Unwrapping promise...');
-          const response = await result.unwrap();
-          console.log('Password reset API response:', response);
+          await result.unwrap();
         } else {
           console.error('Unexpected mutation result type:', result);
           throw new Error('Mutation failed to return a promise');
@@ -152,11 +110,10 @@ const ResetPassword = () => {
         console.error('Mutation failed with error:', mutationError);
         console.error('Trying direct fetch...');
 
-        // Fallback to direct fetch with more debugging
+        // Fallback to direct fetch
         try {
           const { BASE_API_URL } = await import('../../utils/url');
           const apiUrl = `${BASE_API_URL}/auth/password/reset`;
-          console.log('Making direct fetch to:', apiUrl);
 
           const response = await fetch(apiUrl, {
             method: 'POST',
@@ -166,9 +123,7 @@ const ResetPassword = () => {
             body: JSON.stringify(requestData),
           });
 
-          console.log('Fetch response status:', response.status);
           const data = await response.json();
-          console.log('Direct fetch response:', data);
 
           if (!response.ok) {
             throw new Error(data.message || 'Password reset failed');
@@ -199,7 +154,6 @@ const ResetPassword = () => {
   };
 
   const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    console.log('Form onSubmit triggered');
     handleSubmit(e).catch(console.error);
   };
 
@@ -213,7 +167,6 @@ const ResetPassword = () => {
           submitText="Reset Password"
           submitButtonProps={{
             onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-              console.log('Direct button click handler');
               e.preventDefault();
               handleSubmit(e as unknown as React.FormEvent<HTMLFormElement>).catch(console.error);
             }

--- a/src/pages/listAparteFlow/listFlow7.tsx
+++ b/src/pages/listAparteFlow/listFlow7.tsx
@@ -203,7 +203,7 @@ const ListFlow7: React.FC<ListFlow7Props> = ({ onNext, onBack, formData, setForm
       const _propertyId = result.data.id;
 
       // Upload Property Media :)
-      const mediaUploadResult = await Promise.allSettled(
+      await Promise.allSettled(
         media.map((_media) =>
           uploadPropertyMedia({
             id: _propertyId,
@@ -214,7 +214,6 @@ const ListFlow7: React.FC<ListFlow7Props> = ({ onNext, onBack, formData, setForm
       );
       dispatch(setPropertyId(_propertyId));
       dispatch(setFeaturedMedia(media.find((file) => _isImage(file)) || null));
-      console.log('Property Media Upload Result: ', mediaUploadResult);
       onNext();
     } catch (err) {
       console.log('Create property error: ', err);

--- a/src/pages/listAparteFlow/listFlow8.tsx
+++ b/src/pages/listAparteFlow/listFlow8.tsx
@@ -359,11 +359,6 @@ const ListFlow8: React.FC<ListFlow8Props> = ({ onNext, setFormData }) => {
   });
 
   const validateForm = (): boolean => {
-    console.log('Validating form with values:', newUnit);
-    console.log('Selected amenities:', selectedAmenities);
-    console.log('Media files:', mediaFiles);
-    console.log('Cover index:', coverIndex);
-
     const newErrors: FormErrors = {
       title: '',
       description: '',
@@ -380,75 +375,60 @@ const ListFlow8: React.FC<ListFlow8Props> = ({ onNext, setFormData }) => {
 
     let isValid = true;
 
-    // Required fields validation with detailed logging
+    // Required fields validation
     if (!newUnit.title.trim()) {
       newErrors.title = 'Unit title is required';
       isValid = false;
-      console.log('Title validation failed');
     }
     if (!newUnit.description.trim()) {
       newErrors.description = 'Unit description is required';
       isValid = false;
-      console.log('Description validation failed');
     }
     if (!newUnit.units || Number(newUnit.units) <= 0) {
       newErrors.units = 'At least one unit is required';
       isValid = false;
-      console.log('Units validation failed:', newUnit.units);
     }
     if (!newUnit.price || Number(newUnit.price) <= 0) {
       newErrors.price = 'Valid price is required';
       isValid = false;
-      console.log('Price validation failed:', newUnit.price);
     }
     if (!newUnit.max_guests || Number(newUnit.max_guests) <= 0 || Number(newUnit.max_guests) > 20) {
       newErrors.max_guests = 'Guests must be between 1 and 20';
       isValid = false;
-      console.log('Max guests validation failed:', newUnit.max_guests);
     }
 
     // Room validations
     if (newUnit.bedroom === '' || Number(newUnit.bedroom) > 10) {
       newErrors.bedroom = 'Bedrooms must be between 0 and 10';
       isValid = false;
-      console.log('Bedroom validation failed:', newUnit.bedroom);
     }
     if (newUnit.bathroom === '' || Number(newUnit.bathroom) > 10) {
       newErrors.bathroom = 'Bathrooms must be between 0 and 10';
       isValid = false;
-      console.log('Bathroom validation failed:', newUnit.bathroom);
     }
     if (newUnit.living_room === '' || Number(newUnit.living_room) > 5) {
       newErrors.living_room = 'Living rooms must be between 0 and 5';
       isValid = false;
-      console.log('Living room validation failed:', newUnit.living_room);
     }
     if (newUnit.kitchen === '' || Number(newUnit.kitchen) > 3) {
       newErrors.kitchen = 'Kitchens must be between 0 and 3';
       isValid = false;
-      console.log('Kitchen validation failed:', newUnit.kitchen);
     }
 
     // Media and amenities validation
     if (mediaFiles.length === 0) {
       newErrors.media = 'At least one image is required';
       isValid = false;
-      console.log('Media validation failed: No files');
     }
     if (coverIndex === null && mediaFiles.length > 0) {
       newErrors.media = 'Please select a cover photo';
       isValid = false;
-      console.log('Media validation failed: No cover photo selected');
     }
     if (selectedAmenities.length === 0) {
       newErrors.amenities = 'Please select at least one amenity';
       isValid = false;
-      console.log('Amenities validation failed: None selected');
     }
 
-    console.log('Validation errors:', newErrors);
-    console.log('Form is valid:', isValid);
-    
     setErrors(newErrors);
     return isValid;
   };
@@ -482,7 +462,6 @@ const ListFlow8: React.FC<ListFlow8Props> = ({ onNext, setFormData }) => {
   };
 
   const handleSubmission = async () => {
-    console.log('handleSubmission called');
     try {
       if (!propertyId) {
         console.error('PropertyId missing:', propertyId);
@@ -490,7 +469,6 @@ const ListFlow8: React.FC<ListFlow8Props> = ({ onNext, setFormData }) => {
       }
 
       const isValid = validateForm();
-      console.log('Form validation result:', isValid);
       if (!isValid) {
         return;
       }
@@ -541,8 +519,6 @@ const ListFlow8: React.FC<ListFlow8Props> = ({ onNext, setFormData }) => {
 
       // Reset form state
       resetForm();
-
-      console.log('Unit added to pending list');
     } catch (err) {
       console.error('Error adding unit to pending list:', err);
       setErrors(prev => ({
@@ -565,8 +541,6 @@ const ListFlow8: React.FC<ListFlow8Props> = ({ onNext, setFormData }) => {
           amenities: pu.amenities
         }))
       }).unwrap();
-
-      console.log('Add Property Units API Response:', result);
 
       if (!result?.data?.length) {
         throw new Error('Failed to create units: No units returned');
@@ -599,7 +573,6 @@ const ListFlow8: React.FC<ListFlow8Props> = ({ onNext, setFormData }) => {
 
       // Clear pending units
       dispatch(clearPendingUnits());
-      console.log('All units uploaded successfully');
 
     } catch (err) {
       console.error('Upload all units error:', err);


### PR DESCRIPTION
## Finding A5 (LOW) — Debug `console.log` statements in production paths

The landing page shipped debug `console.log` / `console.debug` statements in production code under `src/`. This is a hygiene issue with incidental data-exposure risk (e.g. logging API responses, form state, OTP-flow values to the browser console).

## What changed

**Removed 74 debug `console.log` statements across 14 source files** (diff is `+10 / -111`, effectively subtractive):

| File | Removed |
|------|---------|
| `src/pages/auth/ResetPassword.tsx` | 32 (heaviest — full debug instrumentation of the reset flow, incl. one that logged request data) |
| `src/pages/listAparteFlow/listFlow8.tsx` | 23 (form-validation debug logging) |
| `src/pages/PropertyDetails.tsx` | 2 (logged API response + coordinates) |
| `src/api/bookingsApi.ts` | 4 (RTK Query `onQueryStarted` debug) |
| `src/pages/auth/EmailInput.tsx` | 3 |
| `src/components/Idletimeout/idletimeout.tsx` | 2 |
| `src/context/UserBooking.tsx`, `src/components/booking/PaymentMethodSelection.tsx`, `src/components/forms/FormContainer.tsx`, `src/components/search/ResultsGrid.tsx`, `src/pages/ConfirmBooking.tsx`, `src/pages/PaymentSuccess.tsx`, `src/pages/auth/RequestPasswordReset.tsx`, `src/pages/listAparteFlow/listFlow7.tsx` | 1 each |

**Preserved (not touched):** all `console.error` / `console.warn` calls and `.catch(console.error)` references — these are intentional error reporting; removing them would change error-visibility behavior. (0 `console.error`/`console.warn` lines were removed — verified via diff.)

**Minimal non-log adjustments** required to keep the build green under `noUnusedLocals` / `noUnusedParameters` (these are the only non-deletions):
- `src/api/bookingsApi.ts`: `const { data } = await queryFulfilled;` → `await queryFulfilled;` (×2; `data` was only used by removed logs) and unused first args prefixed `_` (`_bookingId`, `_arg`). The `await` is retained so the existing `console.error` catch still fires.
- `src/pages/listAparteFlow/listFlow7.tsx`: `const mediaUploadResult = await Promise.allSettled(...)` → `await Promise.allSettled(...)` (binding only used by removed log; upload side-effect preserved).
- `src/pages/auth/EmailInput.tsx`: unused `otp` param → `_otp`.
- `src/pages/auth/ResetPassword.tsx`: dropped now-unused `mutationLoading` / `mutationError` destructure and a now-unused `response` binding.

## Deliberately skipped (and why)

- **`console.log` that is the sole body of a catch / arrow / effect** — removing it would create an empty block or alter control flow (out of scope for a subtractive log-removal): `listFlow7.tsx:219` (sole catch body), `WalletDashboard.tsx:218` (sole catch body), `ConfirmBooking.tsx:503` (sole body of a debug-only `useEffect`'s `if`), `EmailInput.tsx:203` (sole body of an `onResend` arrow).
- **`src/lib/help/analytics.ts:21`** — DEV-gated (`if (import.meta.env.DEV)`); Vite dead-code-eliminates it from the production bundle, so no prod exposure. Removing it cleanly would require touching the `if` guard (control flow).
- **`src/api/authApi.ts`** — excluded per finding scope (auth/token review boundary).
- **`src/scratch.js` (3) and `src/utils/errorHandler.example.ts` (7)** — non-production files (unreferenced anywhere in the app; scratchpad / example by name and content). Their `console.log`s are the entire purpose of the files.
- Two already-commented `// console.log` lines (`PropertyDetails.tsx`, `ConfirmBooking.tsx`) — not live statements.

## How validated

- `npm install` — OK (505 packages).
- `npm run build` (`generate-sitemap && tsc -b && vite build`) — **PASS** (exit 0, built in ~51s). The strict `tsc -b` (`noUnusedLocals`/`noUnusedParameters`) confirms no unused-variable regressions. The build-generated `public/sitemap.xml` change was reverted and is **not** part of this PR.
- `npm run lint` (`eslint .`) — lint already fails on the base branch (`origin/dev`: 189 problems / 182 errors). This branch: 190 problems / 183 errors. **Net delta: +1 error** — a single `no-unused-vars` on the underscore-prefixed `_otp` param, a pattern the codebase already carries (`_inputMode`, `_variant`, `_`, `_index`). All other lint findings in touched files are pre-existing `no-explicit-any` etc. unrelated to these edits. No unit-test framework exists (none added).

## Residual risk

- One net-new pre-existing-category lint error (`_otp` unused param). Eliminating it isn't possible without leaving `otp` unprefixed, which would break the `tsc` build gate. Left as-is to keep the build green; consistent with existing repo lint state.
- Removing per-flow debug logs slightly reduces console-level observability during manual debugging of the password-reset and listing flows; user-facing behavior (toasts, error handling, navigation, network calls) is unchanged.

---

Authored by remediation agent — requires human review. Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)