### PR TITLE
feat: implement guest stay extension & discount displays

### DIFF
--- a/src/api/booking.ts
+++ b/src/api/booking.ts
@@ -50,6 +50,32 @@ interface bookingTransactionResponse {
     data?: any;
 }
 
+export interface BookingQuotePayload {
+    unit_id: string;
+    start_date: string;
+    end_date: string;
+    guests_count: number;
+    unit_count: number;
+    referral_code?: string;
+}
+
+export interface BookingQuoteResponse {
+    nights: number;
+    base_price: number;
+    discount_amount: number;
+    discount_policy?: {
+        policy: any;
+        nights: number;
+        discount_amount: string;
+    };
+    total_price: number;
+    caution_fee: number;
+    gateway: string;
+    gateway_fee: string | number;
+    total_payable: string | number;
+    upsell_message?: string;
+}
+
 import { BASE_API_URL } from '../utils/url';
 
 export const bookingApi = createApi({
@@ -86,7 +112,14 @@ export const bookingApi = createApi({
                 body: bookingtransaction,
             }),
         }),
+        getBookingQuote: builder.mutation<{ message: string; data: BookingQuoteResponse }, BookingQuotePayload>({
+            query: (quotePayload) => ({
+                url: "bookings/quote",
+                method: "POST",
+                body: quotePayload,
+            }),
+        }),
     }),
 });
 
-export const { useCreateBookingMutation, useUpdateBookingStatusMutation, useUpdateBookingTransactionMutation } = bookingApi;
+export const { useCreateBookingMutation, useUpdateBookingStatusMutation, useUpdateBookingTransactionMutation, useGetBookingQuoteMutation } = bookingApi;

--- a/src/api/bookingsApi.ts
+++ b/src/api/bookingsApi.ts
@@ -226,6 +226,9 @@ export const bookingsApi = createApi({
         { type: 'Bookings' as const },
       ],
     }),
+    getExtensionQuote: builder.query<any, { bookingId: string, new_end_date: string }>({
+      query: ({ bookingId, new_end_date }) => `bookings/${bookingId}/extension-quote?new_end_date=${new_end_date}`,
+    }),
   }),
 });
 
@@ -239,5 +242,6 @@ export const {
   useGetBookingExtensionsQuery,
   useRequestStayExtensionMutation,
   useCancelExtensionRequestMutation,
+  useGetExtensionQuoteQuery,
 } = bookingsApi;
 export type { BookingsResponse, Booking, Unit, Property, Meta }; 

--- a/src/components/booking/BookingSummary.tsx
+++ b/src/components/booking/BookingSummary.tsx
@@ -66,6 +66,18 @@ const BookingSummary: React.FC<BookingSummaryProps> = ({
             </p>
           </div>
 
+          {booking?.discount_amount > 0 && (
+            <div className="flex justify-between text-green-600">
+              <p className="flex items-center gap-1">
+                <Icon icon="solar:tag-price-bold-duotone" />
+                Discount
+              </p>
+              <p className="font-medium">
+                −{formatPrice(booking.discount_amount)}
+              </p>
+            </div>
+          )}
+
           {!booking?.isExtension && (
             <div className="flex justify-between text-gray-600">
               <p>Caution Fee</p>

--- a/src/components/booking/RequestExtensionModal.tsx
+++ b/src/components/booking/RequestExtensionModal.tsx
@@ -1,0 +1,145 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  CircularProgress,
+  TextField,
+  Alert,
+} from '@mui/material';
+import { format } from 'date-fns';
+import { useGetExtensionQuoteQuery, useRequestStayExtensionMutation } from '../../api/bookingsApi';
+import { toast } from 'react-toastify';
+
+interface RequestExtensionModalProps {
+  open: boolean;
+  onClose: () => void;
+  booking: any;
+}
+
+const PRIMARY = '#028090';
+
+const RequestExtensionModal: React.FC<RequestExtensionModalProps> = ({
+  open,
+  onClose,
+  booking,
+}) => {
+  const [newEndDate, setNewEndDate] = useState<string>('');
+  
+  const { data: quoteData, isFetching: isQuoteLoading, error: quoteError } = useGetExtensionQuoteQuery(
+    { bookingId: booking?.id, new_end_date: newEndDate },
+    { skip: !booking?.id || !newEndDate }
+  );
+
+  const [requestExtension, { isLoading: isRequesting }] = useRequestStayExtensionMutation();
+
+  // Set minimum date to current end date + 1 day
+  const minDate = booking?.end_date ? format(new Date(new Date(booking.end_date).getTime() + 24 * 60 * 60 * 1000), 'yyyy-MM-dd') : '';
+
+  useEffect(() => {
+    if (open) {
+      setNewEndDate('');
+    }
+  }, [open]);
+
+  const handleSubmit = async () => {
+    if (!newEndDate) return;
+    try {
+      await requestExtension({
+        bookingId: booking.id,
+        new_end_date: newEndDate,
+      }).unwrap();
+      toast.success('Extension requested successfully');
+      onClose();
+    } catch (err: any) {
+      toast.error(err?.data?.message || err?.message || 'Failed to request extension');
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Request Stay Extension</DialogTitle>
+      <DialogContent dividers>
+        <Typography variant="body2" sx={{ mb: 2 }}>
+          Your current check-out date is {booking?.end_date ? format(new Date(booking.end_date), 'MMM d, yyyy') : '—'}. Select a new check-out date to see the pricing.
+        </Typography>
+
+        <TextField
+          fullWidth
+          label="New Check-out Date"
+          type="date"
+          value={newEndDate}
+          onChange={(e) => setNewEndDate(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+          inputProps={{ min: minDate }}
+          sx={{ mb: 3 }}
+        />
+
+        {isQuoteLoading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', my: 2 }}>
+            <CircularProgress size={24} />
+          </Box>
+        )}
+
+        {quoteError && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Failed to fetch extension quote.
+          </Alert>
+        )}
+
+        {quoteData && quoteData.data && !isQuoteLoading && (
+          <Box sx={{ bgcolor: 'grey.50', p: 2, borderRadius: 1, border: '1px solid', borderColor: 'divider' }}>
+            <Typography variant="subtitle2" gutterBottom>
+              Extension Summary
+            </Typography>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+              <Typography variant="body2">Extra Nights</Typography>
+              <Typography variant="body2">{quoteData.data.nights}</Typography>
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+              <Typography variant="body2">Base Price ({quoteData.data.nights} extra night{quoteData.data.nights !== 1 ? 's' : ''})</Typography>
+              <Typography variant="body2">₦{Number(quoteData.data.base_price).toLocaleString()}</Typography>
+            </Box>
+            
+            {quoteData.data.discount_amount > 0 && (
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1, color: 'success.main' }}>
+                <Typography variant="body2">Discount</Typography>
+                <Typography variant="body2" fontWeight="bold">−₦{Number(quoteData.data.discount_amount).toLocaleString()}</Typography>
+              </Box>
+            )}
+            
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+              <Typography variant="subtitle2">Additional Amount to Pay</Typography>
+              <Typography variant="subtitle2">₦{Number(quoteData.data.total_payable || quoteData.data.total_price).toLocaleString()}</Typography>
+            </Box>
+            
+            {quoteData.data.upsell_message && (
+              <Box sx={{ mt: 2, p: 1.5, bgcolor: 'primary.50', borderRadius: 1, border: '1px dashed', borderColor: 'primary.200' }}>
+                <Typography variant="caption" sx={{ color: 'primary.800', fontWeight: 500, display: 'block', textAlign: 'center' }}>
+                  💡 {quoteData.data.upsell_message}
+                </Typography>
+              </Box>
+            )}
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isRequesting}>Cancel</Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={!newEndDate || isRequesting || !quoteData?.data}
+          sx={{ bgcolor: PRIMARY, '&:hover': { bgcolor: '#026d7a' } }}
+        >
+          {isRequesting ? <CircularProgress size={20} color="inherit" /> : 'Request Extension'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default RequestExtensionModal;

--- a/src/components/property/BookingSidebar.tsx
+++ b/src/components/property/BookingSidebar.tsx
@@ -41,6 +41,8 @@ interface BookingSidebarProps {
   propertyName?: string;
   propertyId?: string;
   propertyCity?: string;
+  quoteData?: any;
+  isQuoteLoading?: boolean;
 }
 
 const BookingSidebar: React.FC<BookingSidebarProps> = ({
@@ -72,6 +74,8 @@ const BookingSidebar: React.FC<BookingSidebarProps> = ({
   propertyName,
   propertyId,
   propertyCity,
+  quoteData,
+  isQuoteLoading,
 }) => {
   const isRequestToBook = bookingMode === 'REQUEST_TO_BOOK';
   const guestMax =
@@ -263,7 +267,12 @@ const BookingSidebar: React.FC<BookingSidebarProps> = ({
       </Box>
 
       {/* Total Price Breakdown */}
-      <Box sx={{ mb: 2, p: 2, bgcolor: 'action.hover', borderRadius: 2 }}>
+      <Box sx={{ mb: 2, p: 2, bgcolor: 'action.hover', borderRadius: 2, position: 'relative' }}>
+        {isQuoteLoading && (
+          <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, bgcolor: 'rgba(255,255,255,0.7)', zIndex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Skeleton variant="rectangular" width="100%" height="100%" sx={{ opacity: 0.5 }} />
+          </Box>
+        )}
         <Typography variant="subtitle2" gutterBottom>
           Price Details
         </Typography>
@@ -274,9 +283,37 @@ const BookingSidebar: React.FC<BookingSidebarProps> = ({
             {selectedUnits === 1 || !selectedUnits ? '' : 's'}
           </Typography>
           <Typography>
-            {formatPrice(basePrice * nights * selectedUnits)}
+            {formatPrice(quoteData?.base_price ?? (basePrice * nights * selectedUnits))}
           </Typography>
         </Box>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1, color: 'text.secondary' }}>
+          <Typography variant="caption">Standard nightly rate</Typography>
+          <Typography variant="caption">
+            {formatPrice((quoteData?.base_price ?? (basePrice * nights * selectedUnits)) / (nights * (selectedUnits || 1)))} / night
+          </Typography>
+        </Box>
+        
+        {quoteData?.discount_amount > 0 && (
+          <>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1, color: 'success.main' }}>
+              <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                Discount ({quoteData.discount_policy?.policy?.name || 'Long Stay'})
+              </Typography>
+              <Typography variant="body2" fontWeight="bold">
+                −{formatPrice(quoteData.discount_amount)}
+              </Typography>
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1, pl: 1, borderLeft: '2px solid', borderColor: 'success.main' }}>
+              <Typography variant="caption" color="text.secondary">
+                Discounted nightly rate
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {formatPrice((quoteData.base_price - quoteData.discount_amount) / (nights * (selectedUnits || 1)))} / night
+              </Typography>
+            </Box>
+          </>
+        )}
+
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
           <Typography>Caution Fee</Typography>
           <Typography>{formatPrice(Number(cautionFeePercentage))}</Typography>
@@ -295,6 +332,13 @@ const BookingSidebar: React.FC<BookingSidebarProps> = ({
             {formatPrice(totalChargingFee)}
           </Typography>
         </Box>
+        {quoteData?.upsell_message && (
+          <Box sx={{ mt: 2, p: 1.5, bgcolor: 'primary.50', borderRadius: 1, border: '1px dashed', borderColor: 'primary.200' }}>
+            <Typography variant="caption" sx={{ color: 'primary.800', fontWeight: 500, display: 'block', textAlign: 'center' }}>
+              💡 {quoteData.upsell_message}
+            </Typography>
+          </Box>
+        )}
       </Box>
 
       {/* Book / Request Button */}

--- a/src/components/property/MobileBookingSummary.tsx
+++ b/src/components/property/MobileBookingSummary.tsx
@@ -1,4 +1,4 @@
-﻿'use client';
+'use client';
 
 import React, { useState } from 'react';
 import {
@@ -46,6 +46,8 @@ interface MobileBookingSummaryProps {
   propertyId?: string;
   propertyCity?: string;
   unitName?: string;
+  quoteData?: any;
+  isQuoteLoading?: boolean;
 }
 
 export const clampBookingCountFromInput = (e: React.ChangeEvent<HTMLInputElement>, maxUnits: number, onChange: (units: number) => void) => {
@@ -108,6 +110,8 @@ const MobileBookingSummary: React.FC<MobileBookingSummaryProps> = ({
   propertyId,
   propertyCity,
   unitName,
+  quoteData,
+  isQuoteLoading,
 }) => {
   const isRequestToBook = bookingMode === 'REQUEST_TO_BOOK';
   const isMobile = useMediaQuery('(max-width:600px)');
@@ -165,7 +169,7 @@ const MobileBookingSummary: React.FC<MobileBookingSummaryProps> = ({
             variant="h6"
             sx={{ color: 'primary.main', fontWeight: 600 }}
           >
-            {isLoading ? <Skeleton width={100} /> : formatPrice(totalPrice)}
+            {isLoading || isQuoteLoading ? <Skeleton width={100} /> : formatPrice(totalPrice)}
           </Typography>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
             <Typography variant="caption" color="text.secondary">
@@ -340,20 +344,51 @@ const MobileBookingSummary: React.FC<MobileBookingSummaryProps> = ({
               }}
             >
               <Box
-                sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}
+                sx={{ display: 'flex', justifyContent: 'space-between', mb: 1, position: 'relative' }}
               >
+                {isQuoteLoading && (
+                  <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, bgcolor: 'rgba(255,255,255,0.7)', zIndex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <Skeleton variant="rectangular" width="100%" height="100%" sx={{ opacity: 0.5 }} />
+                  </Box>
+                )}
                 <Typography variant="body2">
-                  {formatPrice(datePrice || basePrice)} × {nights} night
+                  {formatPrice(quoteData?.base_price ?? (datePrice || basePrice))} × {nights} night
                   {nights !== 1 ? 's' : ''} ×
                   {!Number.isNaN(selectedUnits) ? selectedUnits : 0} unit
                   {selectedUnits === 1 || !selectedUnits ? '' : 's'}
                 </Typography>
                 <Typography variant="body2">
-                  {formatPrice(
-                    (datePrice || basePrice) * nights * selectedUnits
-                  )}
+                  {formatPrice(quoteData?.base_price ?? ((datePrice || basePrice) * nights * selectedUnits))}
                 </Typography>
               </Box>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1, color: 'text.secondary' }}>
+                <Typography variant="caption">Standard nightly rate</Typography>
+                <Typography variant="caption">
+                  {formatPrice((quoteData?.base_price ?? ((datePrice || basePrice) * nights * selectedUnits)) / (nights * (selectedUnits || 1)))} / night
+                </Typography>
+              </Box>
+
+              {quoteData?.discount_amount > 0 && (
+                <>
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1, color: 'success.main' }}>
+                    <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      Discount ({quoteData.discount_policy?.policy?.name || 'Long Stay'})
+                    </Typography>
+                    <Typography variant="body2" fontWeight="bold">
+                      −{formatPrice(quoteData.discount_amount)}
+                    </Typography>
+                  </Box>
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1, pl: 1, borderLeft: '2px solid', borderColor: 'success.main' }}>
+                    <Typography variant="caption" color="text.secondary">
+                      Discounted nightly rate
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {formatPrice((quoteData.base_price - quoteData.discount_amount) / (nights * (selectedUnits || 1)))} / night
+                    </Typography>
+                  </Box>
+                </>
+              )}
+
               <Box
                 sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}
               >
@@ -376,6 +411,13 @@ const MobileBookingSummary: React.FC<MobileBookingSummaryProps> = ({
                   {formatPrice(totalPrice)}
                 </Typography>
               </Box>
+              {quoteData?.upsell_message && (
+                <Box sx={{ mt: 1.5, p: 1, bgcolor: 'primary.50', borderRadius: 1, border: '1px dashed', borderColor: 'primary.200' }}>
+                  <Typography variant="caption" sx={{ color: 'primary.800', fontWeight: 500, display: 'block', textAlign: 'center' }}>
+                    💡 {quoteData.upsell_message}
+                  </Typography>
+                </Box>
+              )}
               <Button
                 fullWidth
                 variant="contained"

--- a/src/views/BookingDetailsPage.tsx
+++ b/src/views/BookingDetailsPage.tsx
@@ -1,4 +1,4 @@
-﻿'use client';
+'use client';
 
 import React, { useMemo } from 'react';
 import { Link as RouterLink, useParams } from '@/lib/router';
@@ -25,6 +25,7 @@ import {
 import type { Booking, BookingExtension } from '../api/bookingsApi';
 import { useGetProfileQuery } from '../api/profileApi';
 import { extractErrorMessage } from '../utils/errorHandler';
+import RequestExtensionModal from '../components/booking/RequestExtensionModal';
 
 const PRIMARY = '#028090';
 
@@ -76,6 +77,7 @@ const BookingDetailsPage: React.FC = () => {
   } = useGetBookingByIdQuery(bookingId ?? '', {
     skip: !bookingId,
   });
+  const [isExtensionModalOpen, setIsExtensionModalOpen] = React.useState(false);
   const { data: profileData } = useGetProfileQuery();
   const { data: extensionsRaw, isLoading: extLoading } =
     useGetBookingExtensionsQuery(bookingId ?? '', {
@@ -469,6 +471,25 @@ const BookingDetailsPage: React.FC = () => {
             </>
           ) : null}
 
+          {booking && ['CONFIRMED', 'CHECKED_IN'].includes(booking.status) && (
+            <Box sx={{ mt: 3 }}>
+              <Button
+                variant="outlined"
+                onClick={() => setIsExtensionModalOpen(true)}
+                sx={{
+                  color: PRIMARY,
+                  borderColor: PRIMARY,
+                  '&:hover': {
+                    borderColor: '#026d7a',
+                    backgroundColor: 'rgba(2, 128, 144, 0.04)',
+                  }
+                }}
+              >
+                Request Extension
+              </Button>
+            </Box>
+          )}
+
           <Typography
             variant="caption"
             color="text.secondary"
@@ -485,7 +506,18 @@ const BookingDetailsPage: React.FC = () => {
     );
   };
 
-  return <>{content()}</>;
+  return (
+    <>
+      {content()}
+      {booking && (
+        <RequestExtensionModal
+          open={isExtensionModalOpen}
+          onClose={() => setIsExtensionModalOpen(false)}
+          booking={booking}
+        />
+      )}
+    </>
+  );
 };
 
 export default BookingDetailsPage;

--- a/src/views/PropertyDetails.tsx
+++ b/src/views/PropertyDetails.tsx
@@ -27,6 +27,7 @@ import {
   useLazyGetUnitAvailabilityQuery,
 } from '../api/propertiesApi';
 import { BookingContext } from '../context/UserBooking';
+import { useGetBookingQuoteMutation } from '../api/booking';
 import { useAppSelector } from '../hooks';
 import { Icon } from '@iconify/react';
 import MobileBookingSummary from '../components/property/MobileBookingSummary';
@@ -164,6 +165,8 @@ const PropertyDetails: React.FC = () => {
   const [checkInDate, setCheckInDate] = useState<Date | null>(null);
   const [datePrice, setDateprice] = useState<number | null>(null);
   const [checkOutDate, setCheckOutDate] = useState<Date | null>(null);
+  const [getBookingQuote, { data: quoteResponse, isLoading: isQuoteLoading }] = useGetBookingQuoteMutation();
+  const quoteData = quoteResponse?.data;
   const [showConfirmBooking] = useState(false);
   const [selectedUnits, setSelectedUnits] = useState<number>(1);
   const { setBooking } = useContext(BookingContext) || {};
@@ -262,6 +265,18 @@ const PropertyDetails: React.FC = () => {
   ]);
 
   useEffect(() => {
+    if (checkInDate && checkOutDate && value && adults > 0 && selectedUnits > 0) {
+      getBookingQuote({
+        unit_id: value,
+        start_date: formatDateLocal(checkInDate),
+        end_date: formatDateLocal(checkOutDate),
+        guests_count: adults + children,
+        unit_count: selectedUnits,
+      });
+    }
+  }, [checkInDate, checkOutDate, value, adults, children, selectedUnits, getBookingQuote]);
+
+  useEffect(() => {
     if (preservedState) {
       // Restore the preserved state
       if (preservedState.checkInDate)
@@ -311,10 +326,13 @@ const PropertyDetails: React.FC = () => {
     (activeUnit?.media?.[0] as any)?.media_url ||
     (activeUnit?.media?.[0] as any)?.mediaUrl ||
     activeUnit?.media?.[0]?.fileUrl ||
-    (propertyDetail?.media?.[0] as any)?.media_url ||
     (propertyDetail?.media?.[0] as any)?.mediaUrl ||
     propertyDetail?.media?.[0]?.fileUrl ||
     '';
+
+  const finalTotalFee = quoteData ? quoteData.total_payable : (basePrice * nights * selectedUnits + cautionFeePercentage);
+  const finalDiscount = quoteData?.discount_amount || 0;
+  const finalCautionFee = quoteData ? quoteData.caution_fee : cautionFeePercentage;
 
   const handleClickOutside = (event: MouseEvent) => {
     if (
@@ -380,8 +398,9 @@ const PropertyDetails: React.FC = () => {
       pets,
       nights,
       base_price: basePrice,
-      caution_fee: cautionFeePercentage,
-      total_charging_fee: totalChargingFee,
+      caution_fee: finalCautionFee,
+      total_charging_fee: finalTotalFee,
+      discount_amount: finalDiscount,
       unit_image: unitImage || '',
       unit_count: selectedUnits,
       unit_id: value,
@@ -958,8 +977,10 @@ const PropertyDetails: React.FC = () => {
               setPets={setPets}
               isPetAllowed={propertyDetail?.is_pet_allowed || false}
               nights={nights}
-              totalChargingFee={totalChargingFee}
-              cautionFeePercentage={cautionFeePercentage}
+              totalChargingFee={finalTotalFee}
+              cautionFeePercentage={finalCautionFee}
+              quoteData={quoteData}
+              isQuoteLoading={isQuoteLoading}
               handleConfirmBookingClick={handleConfirmBookingClick}
               formatPrice={formatPrice}
               onGuestsChange={(total) => {


### PR DESCRIPTION
## Overview
This PR implements the guest-facing UI for the **Stay Extension & Long-Stay Discount System** as defined in the PRD. It surfaces applied discounts, calculates precise nightly rates, and allows guests to seamlessly extend active bookings.

## Core Features Implemented
- **Initial Booking Displays (`BookingSidebar.tsx` & `MobileBookingSummary.tsx`):**
  - Updated the checkout flow to explicitly itemize the standard nightly rate, the applied long-stay discount deduction, the calculated discounted nightly rate, and the final total.
  - Added threshold upsell prompts to encourage longer initial bookings when a user is close to unlocking a discount tier.
- **Stay Extensions (`RequestExtensionModal.tsx`):**
  - Built the guest stay extension modal allowing users to directly request a new check-out date on active bookings.
  - Integrated the quote API to instantly display an itemized breakdown of base extra night costs, extension discount deductions, and threshold upsell messages.
  - Omitted caution fees from the quote calculations strictly per the PRD rules.